### PR TITLE
add leading to span to control line h1 height

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,7 @@ export default function Home() {
       <div className="m-auto text-center max-w-7xl sm:min-h-[60vh] relative w-full flex flex-col items-center justify-center sm:py-32 py-24 px-5">
         <h1 className="text-3xl font-extrabold tracking-tight sm:text-5xl lg:text-6xl xl:text-7xl">
           Lauro is building{' '}
-          <span className="inline-block leading-[1.1] text-transparent min-h-fit bg-clip-text bg-gradient-to-r from-sky-500 to-blue-500 ">
+          <span className="inline-block leading-[1.1] text-transparent bg-clip-text bg-gradient-to-r from-sky-500 to-blue-500 ">
             badass high-quality
           </span>{' '}
           learning products with friends

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,9 +5,9 @@ export default function Home() {
   return (
     <div>
       <div className="m-auto text-center max-w-7xl sm:min-h-[60vh] relative w-full flex flex-col items-center justify-center sm:py-32 py-24 px-5">
-        <h1 className="text-3xl font-extrabold tracking-tight leading-[1.1] sm:text-5xl lg:text-6xl xl:text-7xl">
+        <h1 className="text-3xl font-extrabold tracking-tight sm:text-5xl lg:text-6xl xl:text-7xl">
           Lauro is building{' '}
-          <span className="inline-block text-transparent bg-clip-text bg-gradient-to-r from-sky-500 to-blue-500 ">
+          <span className="inline-block leading-[1.1] text-transparent min-h-fit bg-clip-text bg-gradient-to-r from-sky-500 to-blue-500 ">
             badass high-quality
           </span>{' '}
           learning products with friends


### PR DESCRIPTION
Noticed some text clipping on your H1, specifically the `g` and `y` on the first line. The reason looked to be that `leading-[1.1]` wasn't getting applied properly but when you swap it onto the span inside the header it adjusts line height as you'd expect.


## Before
![Lauro Silva  laurosilva com](https://user-images.githubusercontent.com/6188161/163603253-4fcb0b45-a0bd-4943-8c1f-a104d846ed01.png)

## After
![Lauro Silva  laurosilva com](https://user-images.githubusercontent.com/6188161/163603408-cb819abb-67c2-4881-a799-a00337c16664.png)


![squinting](https://media4.giphy.com/media/Z9K3pP3bsIm8xu2bKW/giphy.gif?cid=1927fc1buxrq1tqzm58c8awpxrgdyfak49rkclvgqj38bc1r&rid=giphy.gif&ct=g)
